### PR TITLE
Restrict running CI/CD on PRs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -4,6 +4,9 @@ name: GitHub CI
 # run only on main branch.  This avoids duplicated actions on PRs
 on:
   pull_request:
+    branches:
+      - main
+      - release/*
   push:
     tags:
       - "v*"


### PR DESCRIPTION
Add restrictions on running CI/CD pipelines to avoid running the pipeline on all PRs. Only PRs against `main` and `release/*` branches need CI runs.