### PR TITLE
Revert to sphinx 5.3.0 to avoid broken navigation bar.

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -204,7 +204,8 @@ jobs:
       #     retention-days: 7
       
       - name: Deploy Documentation
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+        if: github.event_name == 'push' && contains(github.ref, 'refs/heads/main')
+        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           repository-name: pyansys/pyprimemesh-docs

--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -1,9 +1,0 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-  <div class="bd-toc-item active">
-    {% if pagename.startswith("_autosummary") or pagename.startswith("api")%}
-    {{ generate_nav_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
-    {% else %}
-    {{ generate_nav_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
-    {% endif %}
-  </div>
-</nav>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,7 +1,7 @@
 """Sphinx documentation configuration file."""
 from datetime import datetime
 
-from ansys_sphinx_theme import pyansys_logo_black
+from ansys_sphinx_theme import pyansys_logo_black, ansys_favicon
 
 from ansys.meshing.prime import __version__
 
@@ -21,6 +21,8 @@ release = version = __version__
 html_short_title = html_title = "PyPrimeMesh"
 html_logo = pyansys_logo_black
 html_theme = 'ansys_sphinx_theme'
+
+html_favicon = ansys_favicon
 
 # specify the location of your github repo
 html_theme_options = {

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -1,4 +1,4 @@
-Sphinx==6.1.3
+Sphinx==5.3.0
 numpydoc==1.5.0
 ansys-sphinx-theme==0.8.0
 sphinx-copybutton==0.5.1


### PR DESCRIPTION
Sphinx upgrade to 6+ is broken with ansys logo and navigation bar. For the time being to avoid the breaking, sphinx downgraded to 5.3.0 