### PR TITLE
Fix condition in CI to not publish for dev releases

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -66,7 +66,7 @@ jobs:
 
   macos-build:
     name: Build and Smoke tests (macOS)
-    if: github.event_name == 'push' &&0 startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     needs: [style]
     strategy:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -155,7 +155,7 @@ jobs:
 
   release:
     name: Release project
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [package, macos-build]
     runs-on: ubuntu-latest
     steps:
@@ -185,7 +185,7 @@ jobs:
 
   upload_docs_release:
     name: Upload release documentation
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
     runs-on: ubuntu-latest
     needs: [release]
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -66,7 +66,7 @@ jobs:
 
   macos-build:
     name: Build and Smoke tests (macOS)
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' &&0 startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     needs: [style]
     strategy:


### PR DESCRIPTION
Adding the condition to make sure `dev` releases do not get published on to the documentation webpage. Also, since we have policies protecting against `v*` tags, I changed the condition for tags to check for `v*` in tags.