### PR TITLE
FEAT: Add trame gui to PyPrime

### DIFF
--- a/src/ansys/meshing/prime/graphics/graphics.py
+++ b/src/ansys/meshing/prime/graphics/graphics.py
@@ -7,7 +7,10 @@ from pyvista import _vtk
 from pyvista.plotting.plotting import Plotter
 
 import ansys.meshing.prime as prime
+from ansys.meshing.prime.graphics.trame_gui import TrameVisualizer
 from ansys.meshing.prime.internals import defaults
+
+pv.OFF_SCREEN = True
 
 
 def compute_face_list_from_structured_nodes(nodes, dim):
@@ -479,7 +482,10 @@ class Graphics(object):
         # self._plotter.window_size = [1920, 1017]
         if self._sphinx_build == False:
             self.__update_bt_icons()
-        self._plotter.show()
+
+        visualizer = TrameVisualizer()
+        visualizer.set_scene(self._plotter)
+        visualizer.show()
 
     def __draw_parts(self, parts=[], update=False, spline=False):
         """ """

--- a/src/ansys/meshing/prime/graphics/trame_gui.py
+++ b/src/ansys/meshing/prime/graphics/trame_gui.py
@@ -1,0 +1,51 @@
+"""Module for the trame visualizer."""
+try:
+    from pyvista.trame.ui import plotter_ui
+    from trame.app import get_server
+    from trame.ui.vuetify import SinglePageLayout
+
+    _HAS_TRAME = True
+
+except ModuleNotFoundError:  # pragma: no cover
+    _HAS_TRAME = False
+
+
+class TrameVisualizer:
+    """Trame visualizer class. It will define how the trame view layout will be."""
+
+    def __init__(self) -> None:
+        """Inits server and server related variables."""
+        if not _HAS_TRAME:  # pragma: no cover
+            raise ModuleNotFoundError(
+                "The package 'pyvista[trame]' is required to use this function."
+            )
+
+        self.server = get_server()
+        self.state, self.ctrl = self.server.state, self.server.controller
+
+    def set_scene(self, plotter):
+        """Sets the trame layout view and the mesh to show
+        through the pyvista plotter.
+
+        Parameters
+        ----------
+        plotter : pv.Plotter
+            PyVista plotter with the mesh rendered.
+        """
+        self.state.trame__title = "PyPrime Viewer"
+
+        with SinglePageLayout(self.server) as layout:
+            layout.icon.click = self.ctrl.view_reset_camera
+            layout.title.set_text("PyPrime")
+
+            with layout.content:
+                # Use PyVista UI template for Plotters
+                view = plotter_ui(plotter)
+                self.ctrl.view_update = view.update
+
+            # hide footer with trame watermark
+            layout.footer.hide()
+
+    def show(self):
+        """Starts the server and shows the mesh."""
+        self.server.start()


### PR DESCRIPTION
I was checking the `graphics.py` library and I saw that it was really easy to add the `Trame` visualizer to the project. @ninad-kamat can you try this branch in your local and let me know what do you think? 

![image](https://user-images.githubusercontent.com/17165476/232769064-4ec94700-2e73-495a-852e-efcee4d8dadf.png)
