### PR TITLE
fix: Early docker check causes crash in non docker environments

### DIFF
--- a/doc/changelog.d/1253.fixed.md
+++ b/doc/changelog.d/1253.fixed.md
@@ -1,0 +1,1 @@
+Fix: Early docker check causes crash in non docker environments

--- a/src/ansys/meshing/prime/internals/utils.py
+++ b/src/ansys/meshing/prime/internals/utils.py
@@ -33,7 +33,7 @@ import ansys.meshing.prime.internals.defaults as defaults
 import docker
 
 _LOCAL_PORTS = []
-_DOCKER_CLIENT = docker.from_env()
+_DOCKER_CLIENT = None
 
 
 def make_unique_container_name(name: str):
@@ -337,6 +337,7 @@ def stop_prime_github_container(name):
         Name of the container to stop.
     """
     try:
+        _DOCKER_CLIENT = docker.from_env()
         container = _DOCKER_CLIENT.containers.get(name)
         container.stop()
     except docker.errors.NotFound:


### PR DESCRIPTION
## Description
There is a import level Docker check that causes an exception in systems that do not use Docker. This PR fixes that bug. Currently you cannot import the client from main.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: wrap with feature edges``)
